### PR TITLE
Fix resetOnClose registry read, UIA rect height, LoadString sizes, uninitialized Navigate out-param

### DIFF
--- a/AltTabber/AltTabber.cpp
+++ b/AltTabber/AltTabber.cpp
@@ -337,6 +337,7 @@ void MoveToMonitor(unsigned int monitor)
     auto found = std::find_if(mis.monitors.begin(), mis.monitors.end(), [&hmonitor](MonitorInfo_t& mif)->bool {
         return mif.hMonitor == hmonitor;
     });
+    if(found == mis.monitors.end()) return;
     auto oldMonitor = *found;
 
     newWpl.rcNormalPosition = wpl.rcNormalPosition;

--- a/AltTabber/Registry.cpp
+++ b/AltTabber/Registry.cpp
@@ -101,6 +101,12 @@ void SynchronizeWithRegistry()
             log(_T("RegQueryValue failed %d: errno %d\n"), hr, GetLastError());
             return;
         }
+        g_programState.hotkey.modifiers = (UINT)(ULONG)dModifiers;
+        g_programState.hotkey.key = (UINT)(ULONG)dKey;
+
+        // resetOnClose may be absent in keys created by older versions;
+        // keep the default in that case instead of discarding the hotkey
+        dSize = sizeof(DWORD);
         hr = RegQueryValueEx(phk,
             _T("resetOnClose"),
             0,
@@ -112,9 +118,7 @@ void SynchronizeWithRegistry()
             return;
         }
 
-        g_programState.hotkey.modifiers = (UINT)(ULONG)dModifiers;
-        g_programState.hotkey.key = (UINT)(ULONG)dKey;
-        g_programState.resetOnClose = dKey != 0x0;
+        g_programState.resetOnClose = dResetOnClose != 0x0;
         break;
     }
 }

--- a/AltTabber/UIAutomationProvider.cpp
+++ b/AltTabber/UIAutomationProvider.cpp
@@ -147,8 +147,8 @@ IFACEMETHODIMP AltTabberUIAProvider::get_HostRawElementProvider(IRawElementProvi
 
 IFACEMETHODIMP AltTabberUIAProvider::Navigate(NavigateDirection direction, IRawElementProviderFragment** pRetVal)
 {
+    *pRetVal = NULL;
     if(m_programState->slots.empty()) {
-        *pRetVal = NULL;
         return S_OK;
     }
     switch (direction) {

--- a/AltTabber/UIAutomationProvider.cpp
+++ b/AltTabber/UIAutomationProvider.cpp
@@ -104,14 +104,14 @@ IFACEMETHODIMP AltTabberUIAProvider::GetPropertyValue(PROPERTYID propertyId, VAR
     {
         pRetVal->vt = VT_BSTR;
         TCHAR s[64];
-        LoadString(hInstance, IDS_ALTTABBER_CTRL_TYPE, s, sizeof(s));
+        LoadString(hInstance, IDS_ALTTABBER_CTRL_TYPE, s, _countof(s));
         pRetVal->bstrVal = SysAllocString(s);
     }
     else if(propertyId == UIA_HelpTextPropertyId || propertyId == UIA_FullDescriptionPropertyId) // MS Narrator doesn't pick up the HelpText property for some reason
     {
         pRetVal->vt = VT_BSTR;
         TCHAR s[1024];
-        LoadString(hInstance, IDS_ALTTABBER_CTRL_DESCRIPTION, s, sizeof(s));
+        LoadString(hInstance, IDS_ALTTABBER_CTRL_DESCRIPTION, s, _countof(s));
         pRetVal->bstrVal = SysAllocString(s);
     }
     else if (propertyId == UIA_ControlTypePropertyId)
@@ -361,7 +361,7 @@ IFACEMETHODIMP ThumbnailUIAProvider::GetPropertyValue(PROPERTYID propertyId, VAR
     {
         pRetVal->vt = VT_BSTR;
         TCHAR s[64];
-        LoadString(hInstance, IDS_THUMBNAIL_CTRL_TYPE, s, sizeof(s));
+        LoadString(hInstance, IDS_THUMBNAIL_CTRL_TYPE, s, _countof(s));
 
         TCHAR s1[64];
         swprintf_s(s1, 63, _T("%s %d"), s, m_index);
@@ -472,7 +472,7 @@ IFACEMETHODIMP ThumbnailUIAProvider::get_BoundingRectangle(UiaRect * pRetVal)
     auto& slot = m_programState->slots[m_index];
     pRetVal->left = slot.r.left;
     pRetVal->width = slot.r.right - slot.r.left;
-    pRetVal->height = slot.r.top - slot.r.bottom;
+    pRetVal->height = slot.r.bottom - slot.r.top;
     pRetVal->top = slot.r.top;
 
     return S_OK;


### PR DESCRIPTION
While reading through the code I found a few small bugs. All changes are minimal and behavior-preserving apart from the fixes themselves; built and running fine on Windows 11 (x64).

**Registry.cpp**
- `resetOnClose` was assigned from `dKey` (the hotkey key code, always nonzero), so the setting was effectively always on when the registry key already existed.
- If the `resetOnClose` value is absent (key created by an older version), the early `return` also discarded the already-read `modifiers`/`key`, silently ignoring a custom hotkey. The hotkey is now applied before that query.

**UIAutomationProvider.cpp**
- `ThumbnailUIAProvider::get_BoundingRectangle` returned a negative height (`top - bottom`).
- `LoadString` takes a character count, not a byte count; `sizeof(s)` on a `TCHAR[64]` claims 128 chars for a 64-char buffer (latent stack overflow if the resource strings ever grow). Changed to `_countof`.
- `AltTabberUIAProvider::Navigate` left `*pRetVal` uninitialized for `Parent`/sibling directions and then did `if(*pRetVal) AddRef()` on the garbage pointer.

**AltTabber.cpp**
- `MoveToMonitor` dereferenced `std::find_if`'s result without checking for `end()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)